### PR TITLE
Add JSON serialization options in DI configuration

### DIFF
--- a/src/RentCar.Application/ApplicationDependencyInjection.cs
+++ b/src/RentCar.Application/ApplicationDependencyInjection.cs
@@ -10,6 +10,7 @@ using RentCar.Application.Services.Impl;
 using RentCar.Application.Services.Interfaces;
 using SecureLoginApp.Application.Helpers.GenerateJwt;
 using SecureLoginApp.Application.Services.Impl;
+using System.Text.Json.Serialization;
 
 namespace RentCar.Application
 {
@@ -36,8 +37,12 @@ namespace RentCar.Application
             services.AddSingleton<IRabbitMQProducer, RabbitMQProducer>();
             services.AddHostedService<RabbitMQConsumer>();
             services.AddHttpContextAccessor();
-            
 
+            services.AddControllers()
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.Preserve;
+                });
 
 
 


### PR DESCRIPTION
This commit introduces a new using directive for
`System.Text.Json.Serialization` in `ApplicationDependencyInjection.cs` to support JSON serialization options. It also configures the `AddControllers` method to set the `ReferenceHandler` to `Preserve`, allowing for better management of reference loops during serialization.